### PR TITLE
Add position data to url

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -26,8 +26,10 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiZGVsbGlzZCIsImEiOiJjandmbGc5MG8xZGg1M3pudXl6d
 let map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/light-v9',
-    center: [-75.699, 45.420],
-    zoom: 10
+    center: [-75.6294, 45.3745], 
+    zoom: 11, 
+    bearing: -30,
+    hash: true
 });
 
 /*let excludeYards = getParameterByName('yards') === "false";
@@ -148,6 +150,7 @@ map.on('load', () => {
 function loadLine(line, name) {
     map.addSource(name, {
         'type': 'geojson',
+        attribution: 'Data: City of Ottawa',
         data: line
     });
 
@@ -243,28 +246,6 @@ function loadLine(line, name) {
             map.setFilter(`${name}-labels-hover`, ['all', ['==', 'name', ""], ['==', 'type', 'station-label']]);
             lastFeatureId = undefined;
         }
-    });
-
-    // If all values are loaded, zoom the map to fit all the displayed data.
-    if (count === 4) {
-        zoomMap();
-    }
-}
-
-function zoomMap() {
-    let allPoints = [];
-    allPoints.push(...getLngLatFromFeatures(trillium.features));
-    allPoints.push(...getLngLatFromFeatures(confederationEast.features));
-    allPoints.push(...getLngLatFromFeatures(confederationWest.features));
-    allPoints.push(...getLngLatFromFeatures(confederation.features));
-
-    let bounds = new mapboxgl.LngLatBounds(allPoints[0], allPoints[0]);
-    for (let point of allPoints) {
-        bounds.extend(point);
-    }
-
-    map.fitBounds(bounds, {
-        padding: 24
     });
 
 }


### PR DESCRIPTION
The URL now keeps a bit of location information in it which is updated when the map is moved. This means it's possible to share specific locations on the map just by copying the url (could be handy!)

Added some simple data attribution for the City of Ottawa (from which the data is derived)

Changed the default position of the map to be more centered and properly zoomed on the whole system.

Closes #3 